### PR TITLE
change contributing link to x-common

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ There are some utility methods in the `Makefile` to help with development. The b
 	
 ## Contributing Guide
 
-Please see the [contributing guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data)
+Please see the [contributing guide](https://github.com/exercism/x-common/blob/master/CONTRIBUTING.md)
 
 


### PR DESCRIPTION
@masters3d 

It currently points to a very short one for the x-api, now points to the x-common one.